### PR TITLE
Fixed warning using README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ```yaml
 -   repo: git://github.com/doublify/pre-commit-clang-format
-    sha: master
+    rev: master
     hooks:
     -   id: clang-format
 ```


### PR DESCRIPTION
```
[WARNING] Unexpected key(s) present on git://github.com/doublify/pre-commit-clang-format: sha
```