### PR TITLE
Add .mm file extension

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -3,5 +3,5 @@
     description: Format files with ClangFormat.
     entry: clang-format
     language: system
-    files: \.(c|cc|cxx|cpp|frag|glsl|h|hpp|hxx|ih|ispc|ipp|java|js|m|proto|vert)$
+    files: \.(c|cc|cxx|cpp|frag|glsl|h|hpp|hxx|ih|ispc|ipp|java|js|m|mm|proto|vert)$
     args: ['-fallback-style=none', '-i']


### PR DESCRIPTION
The .mm extension is used for Objective-C++ sources, which can be formatted with clang-format.