### PR TITLE
Fix hook not writing when passing custom args

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,7 +1,7 @@
 -   id: clang-format
     name: clang-format
     description: Format files with ClangFormat.
-    entry: clang-format
+    entry: clang-format -i
     language: system
     files: \.(c|cc|cxx|cpp|frag|glsl|h|hpp|hxx|ih|ispc|ipp|java|js|m|mm|proto|vert)$
-    args: ['-fallback-style=none', '-i']
+    args: ['-fallback-style=none']


### PR DESCRIPTION
If you use this hook with this `.pre-commit-config.yaml`

```yaml
-   repo: https://github.com/doublify/pre-commit-clang-format
    rev: 98bafc4f1e69f12070be015b34b2c15d3a0d2f2a
    hooks:
    -   id: clang-format
        args: [-style=file]
```

it will cause the hook to have no effect, because the `-i` (inplace) argument from `args` gets replaced by the args you provided. With this change, only the fallback style argument will be removed if you set your own `args`.

I haven't actually tried it, but this is the way https://github.com/prettier/prettier/blob/master/.pre-commit-hooks.yaml works.