### PR TITLE
Add textproto as a valid ClangFormat file

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -3,5 +3,5 @@
     description: Format files with ClangFormat.
     entry: clang-format -i
     language: system
-    files: \.(c|cc|cxx|cpp|frag|glsl|h|hpp|hxx|ih|ispc|ipp|java|js|m|mm|proto|vert)$
+    files: \.(c|cc|cxx|cpp|frag|glsl|h|hpp|hxx|ih|ispc|ipp|java|js|m|mm|proto|textproto|vert)$
     args: ['-fallback-style=none']


### PR DESCRIPTION
ClangFormat recognizes .textproto files and will format in TextProto format.