### PR TITLE
Specify dependency on the clang-format Python distribution

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -5,3 +5,4 @@
     language: system
     files: \.(c|cc|cxx|cpp|frag|glsl|h|hpp|hxx|ih|ispc|ipp|java|js|m|mm|proto|textproto|vert)$
     args: ['-fallback-style=none']
+    additional_dependencies: [clang-format]


### PR DESCRIPTION
I have recently reworked the Python distribution of clang-format so that it includes the latest versions of clang-format and builds wheels for a variety of platforms. See these links:

* The repository with the [packaging code](https://github.com/ssciwr/clang-format-wheel)
* The [PyPI package](https://github.com/ssciwr/clang-format-wheel)
* The [list of available platform wheels](https://pypi.org/project/clang-format/#files)

It would be great to have the hook depend on this package.